### PR TITLE
Handle pvc resize issues

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -326,10 +326,12 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 			log.Info("failed to ensure version, running with default", "error", err)
 		}
 	}
-	err = r.reconcilePersistentVolumes(ctx, o)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "reconcile persistent volumes")
-	}
+
+	// TODO: Commenting out as we currently don't use volume resize also kubevirt hostpath-csi filesystem mount issue needs to be addressed
+	// err = r.reconcilePersistentVolumes(ctx, o)
+	// if err != nil {
+	// 	return reconcile.Result{}, errors.Wrap(err, "reconcile persistent volumes")
+	// }
 
 	err = r.reconcileSSL(ctx, o)
 	if err != nil {


### PR DESCRIPTION
https://platform9.atlassian.net/browse/PCD-1249

As part of current percona we don't use volume resize, also its causing issues w.r.t kubevirt hostpath-csi filesystem mount sizes. 